### PR TITLE
Ella via Elementary: Update accepted_values test error threshold to > 100 rows

### DIFF
--- a/models/schema.yml
+++ b/models/schema.yml
@@ -167,3 +167,12 @@ models:
 
       - name: gift_card_amount
         description: Amount of the order (AUD) paid for by gift card
+
+  - name: one
+    columns:
+      - name: one
+        tests:
+          - accepted_values:
+              values: [2, 3]
+              error_if: "> 100"
+              warn_if: "> 2"


### PR DESCRIPTION
## Summary\n\nThis PR updates the accepted_values test on the `one` column of the `one` model to:\n\n1. **Uncomment the error_if condition** as requested\n2. **Change the error threshold** from `!= 0` to `> 100`\n\n## Changes\n\n- Added model configuration for the `one` model in `models/schema.yml`\n- Set the accepted_values test to:\n  - `values: [2, 3]` (unchanged)\n  - `error_if: \"> 100\"` (uncommented and updated threshold)\n  - `warn_if: \"> 2\"` (keeping existing warn condition)\n\n## Impact\n\nWith this change, the test will:\n- ✅ **Pass** if ≤ 100 invalid rows are found\n- ⚠️ **Warn** if > 2 invalid rows are found  \n- ❌ **Fail** only if > 100 invalid rows are found\n\nThis makes the test more tolerant of data quality issues while still providing early warning signals.\n"<br><br>Created by: `ella+123@elementary-data.com`